### PR TITLE
Resolve base properties correctly

### DIFF
--- a/src/main/java/au/com/titanclass/flatmate/ThreadGroupProperties.java
+++ b/src/main/java/au/com/titanclass/flatmate/ThreadGroupProperties.java
@@ -12,11 +12,9 @@ import java.util.function.BiConsumer;
 
 class ThreadGroupProperties extends Properties {
   private final ConcurrentHashMap<ThreadGroup, Properties> byThreadGroup;
-  private final Properties systemProperties;
 
-  ThreadGroupProperties(final Properties systemProperties) {
+  ThreadGroupProperties() {
     this.byThreadGroup = new ConcurrentHashMap<>();
-    this.systemProperties = systemProperties;
   }
 
   void register(final Properties props) {
@@ -127,7 +125,7 @@ class ThreadGroupProperties extends Properties {
 
     while (true) {
       if (threadGroup == null) {
-        return systemProperties;
+        return System.getProperties();
       } else {
         final Properties props = byThreadGroup.get(threadGroup);
 


### PR DESCRIPTION
Prior to this commit, an application wouldn’t always see a property value declared when starting flatmate itself.

Calls to System.getProperty would correctly propagate up the hierarchy of Property objects. However, any calls to enumerate properties would not (correctly) return those properties further up in the hierarchy.

The change here is to ensure that each new thread group’s property starts with a replica of the system property object. This way, the thread group property object will return all of the properties provided to flatmate itself.