### PR TITLE
Ensure that get() will not stackoverflow if thread group doesn't have custom properties defined

### DIFF
--- a/src/main/java/au/com/titanclass/flatmate/App.java
+++ b/src/main/java/au/com/titanclass/flatmate/App.java
@@ -36,13 +36,15 @@ public class App {
 
     final List<LoadedJarApp> entries = classLoadersWithMainClass(rootClassLoader, jarApps);
 
+    final Properties systemProperties = System.getProperties();
+
     final Map<Object, Object> systemPropertyMap =
-        System.getProperties()
+        systemProperties
             .entrySet()
             .stream()
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-    final ThreadGroupProperties threadGroupProperties = new ThreadGroupProperties();
+    final ThreadGroupProperties threadGroupProperties = new ThreadGroupProperties(systemProperties);
 
     System.setProperties(threadGroupProperties);
 

--- a/src/main/java/au/com/titanclass/flatmate/ThreadGroupProperties.java
+++ b/src/main/java/au/com/titanclass/flatmate/ThreadGroupProperties.java
@@ -12,9 +12,11 @@ import java.util.function.BiConsumer;
 
 class ThreadGroupProperties extends Properties {
   private final ConcurrentHashMap<ThreadGroup, Properties> byThreadGroup;
+  private final Properties systemProperties;
 
-  ThreadGroupProperties() {
+  ThreadGroupProperties(final Properties systemProperties) {
     this.byThreadGroup = new ConcurrentHashMap<>();
+    this.systemProperties = systemProperties;
   }
 
   void register(final Properties props) {
@@ -125,7 +127,7 @@ class ThreadGroupProperties extends Properties {
 
     while (true) {
       if (threadGroup == null) {
-        return System.getProperties();
+        return systemProperties;
       } else {
         final Properties props = byThreadGroup.get(threadGroup);
 


### PR DESCRIPTION
Fixes #5 

In particular, this is fixing some some worker thread spawned by the JVM without a thread group that is crashing.