### PR TITLE
Implement support for readiness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,21 @@ which yields:
 [INFO] [12/08/2018 18:58:22.720] [ForkJoinPool.commonPool-worker-1] [DeviceProvisionerServer(akka://deviceprovisioner)] Server listening on /127.0.0.1:9871
 ```
 
+Flatmate includes a readiness feature that can wait to start applications based on the binding of a TCP socket. The following will only start the program contained in `bar.jar` once `foo.jar` binds to port 9870:
+
+```bash
+java -jar ~/work/farmco/roommate/target/flatmate-1.0.0-SNAPSHOT.jar \
+  ~/work/farmco/lora-device-provisioner/backend/iox-sss/target/lora-device-provisioner-iox-sss-0.1.0-SNAPSHOT.jar -Dstreambed.http-server.bind.port=9870 -- -- \
+  ~/work/farmco/lora-device-provisioner/backend/iox-sss/target/lora-device-provisioner-iox-sss-0.1.0-SNAPSHOT.jar -ready tcp://localhost:9870 -Dstreambed.http-server.bind.port=9871
+```
+
 ### Building a JAR
 
 ```bash
 sbt package
 ```
 
-## Contribution policy ##
+## Contribution policy
 
 Contributions via GitHub pull requests are gladly accepted from their original author. Along with
 any pull requests, please state that the contribution is your original work and that you license
@@ -53,7 +61,7 @@ explicitly, by submitting any copyrighted material via pull request, email, or o
 agree to license the material under the project's open source license and warrant that you have the
 legal authority to do so.
 
-## License ##
+## License
 
 This code is open source software licensed under the
 [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0) license.

--- a/src/main/java/au/com/titanclass/flatmate/JarApp.java
+++ b/src/main/java/au/com/titanclass/flatmate/JarApp.java
@@ -25,17 +25,31 @@ class JarApp {
   final Path path;
   final List<Map.Entry<String, String>> properties;
   final List<String> args;
+  final List<ReadinessCheck> readinessChecks;
 
   JarApp(
-      final Path path, final List<Map.Entry<String, String>> properties, final List<String> args) {
+      final Path path,
+      final List<Map.Entry<String, String>> properties,
+      final List<String> args,
+      final List<ReadinessCheck> readinessChecks) {
     this.path = path;
     this.properties = properties;
     this.args = args;
+    this.readinessChecks = readinessChecks;
   }
 
   @Override
   public String toString() {
-    return "JarApp{" + "path=" + path + ", properties=" + properties + ", args=" + args + '}';
+    return "JarApp{"
+        + "path="
+        + path
+        + ", properties="
+        + properties
+        + ", args="
+        + args
+        + ", readinessChecks="
+        + readinessChecks
+        + '}';
   }
 
   @Override
@@ -45,11 +59,12 @@ class JarApp {
     final JarApp jarApp = (JarApp) o;
     return Objects.equals(path, jarApp.path)
         && Objects.equals(properties, jarApp.properties)
-        && Objects.equals(args, jarApp.args);
+        && Objects.equals(args, jarApp.args)
+        && Objects.equals(readinessChecks, jarApp.readinessChecks);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(path, properties, args);
+    return Objects.hash(path, properties, args, readinessChecks);
   }
 }

--- a/src/main/java/au/com/titanclass/flatmate/ReadinessCheck.java
+++ b/src/main/java/au/com/titanclass/flatmate/ReadinessCheck.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Titan Class Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.com.titanclass.flatmate;
+
+/**
+ * Defines a condition that must become true before Flatmate will start the next application.
+ *
+ * <p>Currently, only TCP readiness checks are defined.
+ */
+public interface ReadinessCheck {
+  default void waitUntilReady() throws Exception {
+    while (!isReady()) {
+      Thread.sleep(1000);
+    }
+  }
+
+  /**
+   * Defines if the check is ready. This will be polled indefinitely until either an exception is
+   * thrown (which will cause the JVM to exit) or true is returned.
+   */
+  boolean isReady() throws Exception;
+}

--- a/src/main/java/au/com/titanclass/flatmate/TcpReadinessCheck.java
+++ b/src/main/java/au/com/titanclass/flatmate/TcpReadinessCheck.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Titan Class Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.com.titanclass.flatmate;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.Objects;
+
+/** A readiness check that waits until the specified host and port are bound. */
+public class TcpReadinessCheck implements ReadinessCheck {
+  private final String host;
+  private final int port;
+
+  TcpReadinessCheck(final String host, final int port) {
+    this.host = host;
+    this.port = port;
+  }
+
+  @Override
+  public boolean isReady() {
+    boolean ready = false;
+
+    try {
+      final Socket socket = new Socket(host, port);
+
+      ready = true;
+
+      socket.close();
+    } catch (final IOException e) {
+      // note that if close threw the exception, we're ready
+    }
+
+    return ready;
+  }
+
+  @Override
+  public String toString() {
+    return "TcpReadinessCheck{" + "host='" + host + '\'' + ", port=" + port + '}';
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final TcpReadinessCheck that = (TcpReadinessCheck) o;
+    return port == that.port && Objects.equals(host, that.host);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(host, port);
+  }
+}

--- a/src/test/java/au/com/titanclass/flatmate/ReadinessChecksTests.java
+++ b/src/test/java/au/com/titanclass/flatmate/ReadinessChecksTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Titan Class Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.com.titanclass.flatmate;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public class ReadinessChecksTests {
+  @Test
+  public void test() throws Exception {
+    final long startTimeMs = System.nanoTime();
+    final long endTimeMs = startTimeMs + 10000000000L;
+
+    final ServerSocket initialServerSocket = new ServerSocket(0);
+    final int port = initialServerSocket.getLocalPort();
+    initialServerSocket.close();
+
+    final TcpReadinessCheck tcpReadinessCheck = new TcpReadinessCheck("localhost", port);
+
+    assertFalse(tcpReadinessCheck.isReady());
+
+    final ServerSocket serverSocket = new ServerSocket(port);
+
+    new Thread(
+            () -> {
+              try {
+
+                while (System.nanoTime() < endTimeMs) {
+                  serverSocket.accept().close();
+                }
+
+                serverSocket.close();
+              } catch (IOException e1) {
+                try {
+                  serverSocket.close();
+                } catch (IOException e2) {
+                  RuntimeException e3 = new RuntimeException(e2);
+                  e1.addSuppressed(e1);
+                  throw e3;
+                }
+
+                throw new RuntimeException(e1);
+              }
+            })
+        .start();
+
+    tcpReadinessCheck.waitUntilReady();
+  }
+}


### PR DESCRIPTION
Implement support for readiness checks

In addition to properties via -D, readiness checks can be specified for each application.

When Flatmate starts applications, it will wait until all of their readiness checks have completed before starting the next one.

Initially, a readiness check that checks if a TCP socket is bound is provided.