### PR TITLE
Sharing resources via JNDI

### DIFF
--- a/src/main/java/au/com/titanclass/flatmate/FlatmateContext.java
+++ b/src/main/java/au/com/titanclass/flatmate/FlatmateContext.java
@@ -18,137 +18,140 @@ package au.com.titanclass.flatmate;
 
 import javax.naming.*;
 import java.util.Hashtable;
+import java.util.concurrent.ConcurrentHashMap;
 
+/** A simple JNDI context backed by a <code>ConcurrentHashMap</code> */
 public class FlatmateContext implements Context {
 
-  private static Hashtable<String, Object> things = new Hashtable<>();
+  private static ConcurrentHashMap<String, Object> things = new ConcurrentHashMap<>();
 
   @Override
-  public Object lookup(Name name) throws NamingException {
+  public Object lookup(Name name) {
     return lookup(name.get(0));
   }
 
   @Override
-  public Object lookup(String name) throws NamingException {
-    System.out.println("Lookup " + name + " in FlatmateContext");
+  public Object lookup(String name) {
+    if (name == null) throw new IllegalArgumentException("name must not be null");
     return things.get(name);
   }
 
   @Override
-  public void bind(Name name, Object obj) throws NamingException {
+  public void bind(Name name, Object obj) {
     bind(name.get(0), obj);
   }
 
   @Override
-  public void bind(String name, Object obj) throws NamingException {
-    System.out.println("Binding " + name + " in FlatmateContext");
+  public void bind(String name, Object obj) {
+    if (name == null) throw new IllegalArgumentException("name must not be null");
+    if (obj == null) throw new IllegalArgumentException("obj must not be null");
     things.put(name, obj);
   }
 
   @Override
-  public void rebind(Name name, Object obj) throws NamingException {}
+  public void rebind(Name name, Object obj) {}
 
   @Override
-  public void rebind(String name, Object obj) throws NamingException {}
+  public void rebind(String name, Object obj) {}
 
   @Override
-  public void unbind(Name name) throws NamingException {}
+  public void unbind(Name name) {}
 
   @Override
-  public void unbind(String name) throws NamingException {}
+  public void unbind(String name) {}
 
   @Override
-  public void rename(Name oldName, Name newName) throws NamingException {}
+  public void rename(Name oldName, Name newName) {}
 
   @Override
-  public void rename(String oldName, String newName) throws NamingException {}
+  public void rename(String oldName, String newName) {}
 
   @Override
-  public NamingEnumeration<NameClassPair> list(Name name) throws NamingException {
+  public NamingEnumeration<NameClassPair> list(Name name) {
     return null;
   }
 
   @Override
-  public NamingEnumeration<NameClassPair> list(String name) throws NamingException {
+  public NamingEnumeration<NameClassPair> list(String name) {
     return null;
   }
 
   @Override
-  public NamingEnumeration<Binding> listBindings(Name name) throws NamingException {
+  public NamingEnumeration<Binding> listBindings(Name name) {
     return null;
   }
 
   @Override
-  public NamingEnumeration<Binding> listBindings(String name) throws NamingException {
+  public NamingEnumeration<Binding> listBindings(String name) {
     return null;
   }
 
   @Override
-  public void destroySubcontext(Name name) throws NamingException {}
+  public void destroySubcontext(Name name) {}
 
   @Override
-  public void destroySubcontext(String name) throws NamingException {}
+  public void destroySubcontext(String name) {}
 
   @Override
-  public Context createSubcontext(Name name) throws NamingException {
+  public Context createSubcontext(Name name) {
     return null;
   }
 
   @Override
-  public Context createSubcontext(String name) throws NamingException {
+  public Context createSubcontext(String name) {
     return null;
   }
 
   @Override
-  public Object lookupLink(Name name) throws NamingException {
+  public Object lookupLink(Name name) {
     return null;
   }
 
   @Override
-  public Object lookupLink(String name) throws NamingException {
+  public Object lookupLink(String name) {
     return null;
   }
 
   @Override
-  public NameParser getNameParser(Name name) throws NamingException {
+  public NameParser getNameParser(Name name) {
     return null;
   }
 
   @Override
-  public NameParser getNameParser(String name) throws NamingException {
+  public NameParser getNameParser(String name) {
     return null;
   }
 
   @Override
-  public Name composeName(Name name, Name prefix) throws NamingException {
+  public Name composeName(Name name, Name prefix) {
     return null;
   }
 
   @Override
-  public String composeName(String name, String prefix) throws NamingException {
+  public String composeName(String name, String prefix) {
     return null;
   }
 
   @Override
-  public Object addToEnvironment(String propName, Object propVal) throws NamingException {
+  public Object addToEnvironment(String propName, Object propVal) {
     return null;
   }
 
   @Override
-  public Object removeFromEnvironment(String propName) throws NamingException {
+  public Object removeFromEnvironment(String propName) {
     return null;
   }
 
   @Override
-  public Hashtable<?, ?> getEnvironment() throws NamingException {
+  public Hashtable<?, ?> getEnvironment() {
     return null;
   }
 
   @Override
-  public void close() throws NamingException {}
+  public void close() {}
 
   @Override
-  public String getNameInNamespace() throws NamingException {
+  public String getNameInNamespace() {
     return null;
   }
 }

--- a/src/main/java/au/com/titanclass/flatmate/FlatmateContext.java
+++ b/src/main/java/au/com/titanclass/flatmate/FlatmateContext.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2018 Titan Class Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.com.titanclass.flatmate;
+
+import javax.naming.*;
+import java.util.Hashtable;
+
+public class FlatmateContext implements Context {
+
+  private static Hashtable<String, Object> things = new Hashtable<>();
+
+  @Override
+  public Object lookup(Name name) throws NamingException {
+    return lookup(name.get(0));
+  }
+
+  @Override
+  public Object lookup(String name) throws NamingException {
+    System.out.println("Lookup " + name + " in FlatmateContext");
+    return things.get(name);
+  }
+
+  @Override
+  public void bind(Name name, Object obj) throws NamingException {
+    bind(name.get(0), obj);
+  }
+
+  @Override
+  public void bind(String name, Object obj) throws NamingException {
+    System.out.println("Binding " + name + " in FlatmateContext");
+    things.put(name, obj);
+  }
+
+  @Override
+  public void rebind(Name name, Object obj) throws NamingException {}
+
+  @Override
+  public void rebind(String name, Object obj) throws NamingException {}
+
+  @Override
+  public void unbind(Name name) throws NamingException {}
+
+  @Override
+  public void unbind(String name) throws NamingException {}
+
+  @Override
+  public void rename(Name oldName, Name newName) throws NamingException {}
+
+  @Override
+  public void rename(String oldName, String newName) throws NamingException {}
+
+  @Override
+  public NamingEnumeration<NameClassPair> list(Name name) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public NamingEnumeration<NameClassPair> list(String name) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public NamingEnumeration<Binding> listBindings(Name name) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public NamingEnumeration<Binding> listBindings(String name) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public void destroySubcontext(Name name) throws NamingException {}
+
+  @Override
+  public void destroySubcontext(String name) throws NamingException {}
+
+  @Override
+  public Context createSubcontext(Name name) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public Context createSubcontext(String name) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public Object lookupLink(Name name) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public Object lookupLink(String name) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public NameParser getNameParser(Name name) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public NameParser getNameParser(String name) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public Name composeName(Name name, Name prefix) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public String composeName(String name, String prefix) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public Object addToEnvironment(String propName, Object propVal) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public Object removeFromEnvironment(String propName) throws NamingException {
+    return null;
+  }
+
+  @Override
+  public Hashtable<?, ?> getEnvironment() throws NamingException {
+    return null;
+  }
+
+  @Override
+  public void close() throws NamingException {}
+
+  @Override
+  public String getNameInNamespace() throws NamingException {
+    return null;
+  }
+}

--- a/src/main/java/au/com/titanclass/flatmate/FlatmateContextFactory.java
+++ b/src/main/java/au/com/titanclass/flatmate/FlatmateContextFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Titan Class Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.com.titanclass.flatmate;
+
+import javax.naming.*;
+import javax.naming.spi.InitialContextFactory;
+import java.util.Hashtable;
+
+public class FlatmateContextFactory implements InitialContextFactory {
+
+  public Context getInitialContext(Hashtable<?, ?> env) {
+    return new FlatmateContext();
+  }
+}

--- a/src/main/java/au/com/titanclass/flatmate/JndiReadinessCheck.java
+++ b/src/main/java/au/com/titanclass/flatmate/JndiReadinessCheck.java
@@ -26,9 +26,13 @@ public class JndiReadinessCheck implements ReadinessCheck {
   private Context ctx;
   private String name;
 
+  /**
+   * A ReadinessCheck that waits until a named value is available in the <code>FlatmateContext
+   * </code> JNDI context
+   *
+   * @param name The name of the object to lookup
+   */
   JndiReadinessCheck(String name) {
-
-    System.out.println("Constructing Context for readiness check for " + name);
 
     this.name = name;
     Properties props = new Properties();
@@ -38,18 +42,14 @@ public class JndiReadinessCheck implements ReadinessCheck {
     try {
       ctx = new InitialContext(props);
     } catch (NamingException e) {
-      System.out.println("Naming exception " + e.getMessage());
+      System.err.println("Naming exception " + e.getMessage());
       e.printStackTrace();
+      System.exit(1);
     }
-
-    System.out.println("Initialising context in test-app-1");
   }
 
   @Override
   public boolean isReady() throws Exception {
-    System.out.println("Performing readiness check for " + name);
-    boolean result = ctx.lookup(name) != null;
-    System.out.println("Readiness check for " + name + " returned " + result);
-    return result;
+    return ctx.lookup(name) != null;
   }
 }

--- a/src/main/java/au/com/titanclass/flatmate/JndiReadinessCheck.java
+++ b/src/main/java/au/com/titanclass/flatmate/JndiReadinessCheck.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Titan Class Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.com.titanclass.flatmate;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Properties;
+
+public class JndiReadinessCheck implements ReadinessCheck {
+
+  private Context ctx;
+  private String name;
+
+  JndiReadinessCheck(String name) {
+
+    System.out.println("Constructing Context for readiness check for " + name);
+
+    this.name = name;
+    Properties props = new Properties();
+
+    props.put(Context.INITIAL_CONTEXT_FACTORY, "au.com.titanclass.flatmate.FlatmateContextFactory");
+
+    try {
+      ctx = new InitialContext(props);
+    } catch (NamingException e) {
+      System.out.println("Naming exception " + e.getMessage());
+      e.printStackTrace();
+    }
+
+    System.out.println("Initialising context in test-app-1");
+  }
+
+  @Override
+  public boolean isReady() throws Exception {
+    System.out.println("Performing readiness check for " + name);
+    boolean result = ctx.lookup(name) != null;
+    System.out.println("Readiness check for " + name + " returned " + result);
+    return result;
+  }
+}

--- a/src/test/java/au/com/titanclass/flatmate/JndiReadinessCheckTests.java
+++ b/src/test/java/au/com/titanclass/flatmate/JndiReadinessCheckTests.java
@@ -16,14 +16,24 @@
 
 package au.com.titanclass.flatmate;
 
-import javax.naming.*;
-import javax.naming.spi.InitialContextFactory;
-import java.util.Hashtable;
+import org.junit.Test;
 
-/** A simple JNDI context factory which will create a <code>FlatmateContext</code> */
-public class FlatmateContextFactory implements InitialContextFactory {
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-  public Context getInitialContext(Hashtable<?, ?> env) {
-    return new FlatmateContext();
+public class JndiReadinessCheckTests {
+  @Test
+  public void test() throws Exception {
+
+    final String testJndiName = "test-jndi-name";
+    final JndiReadinessCheck jndiReadinessCheck = new JndiReadinessCheck(testJndiName);
+
+    assertFalse(jndiReadinessCheck.isReady());
+
+    new FlatmateContext().bind(testJndiName, new Object());
+
+    jndiReadinessCheck.waitUntilReady();
+
+    assertTrue(jndiReadinessCheck.isReady());
   }
 }

--- a/src/test/java/au/com/titanclass/flatmate/TcpReadinessCheckTests.java
+++ b/src/test/java/au/com/titanclass/flatmate/TcpReadinessCheckTests.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.ServerSocket;
 
-public class ReadinessChecksTests {
+public class TcpReadinessCheckTests {
   @Test
   public void test() throws Exception {
     final long startTimeMs = System.nanoTime();


### PR DESCRIPTION
This is a minimal JNDI context (FlatmateContextFactory / FlatmateContext) which uses a static Hashtable to store references. There's also a JndiReadinessCheck which implements the ReadinessCheck interface to enable waiting until a named JNDI reference is available. There are a couple of projects I've been using to test this and which show usage at https://github.com/stevewillcock/flatmate-test-apps - in the test projects, there's one jar which registers the shared actor context and two other jars (actually one jar with two configs) which wait and then lookup and use the actor context. It works ok for this simple case but it would be good to understand the intended use and constraints here a bit more. There are no unit tests for the new functionality so far, some extraneous console logging, and no proper error handling. I can add tests and clean up the rest if we agree on the approach. Note that using an assembly (fat jar) for the hosted projects will disallow sharing between different assemblies as the shared objects end up being a different type (e.g. akka.actor.ActorSystem in assembly A is not the same as akka.actor.ActorSystem in assembly B).